### PR TITLE
Update .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["es2015", "stage-2"],
+  "presets": ["env", "stage-2"],
   "plugins": ["transform-runtime"],
   "comments": false
 }


### PR DESCRIPTION
Module build failed: Error: Couldn't find preset "es2015" relative to directory.
We recommend using babel-preset-env now: please read babeljs.io/env to update! -> http://babeljs.io/env